### PR TITLE
Including the common function file directly in composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ use NaiPosTagger\Models\NaiPosArr;
 
 include('vendor/autoload.php');
 
-include(__DIR__ . '/vendor/nai-php/naipostagger/src/Utilities/common_functions_helper.php');
-
 define('DICTIONARIES_PATH', __DIR__ . '/./dictionaries/dictionaries-');
 
 define('TRAITS_PATH', __DIR__ . '/./vendor/nai-php/naipostagger/src/');

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,10 @@
     "autoload": {
         "psr-4": {
             "NaiPosTagger\\": "src/"
-        }
+        },
+	"files": [
+	    "src/Utilities/common_functions_helper.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/tests/EnPosTagger1Test.php
+++ b/tests/EnPosTagger1Test.php
@@ -24,8 +24,6 @@ define('TRAITS_PATH', __DIR__ . '/../src/');
 
 require_once (realpath(__DIR__ . '/../../../vendor/autoload.php'));
 
-require_once realpath(__DIR__ . '/../../../vendor/nai-php/naipostagger/src/Utilities/common_functions_helper.php');
-
 
 /**
  * Tests for english language pos tagging


### PR DESCRIPTION
No reason to do

```
include(__DIR__ . '/vendor/nai-php/naipostagger/src/Utilities/common_functions_helper.php');
```

Files can also be added to composer directly